### PR TITLE
Add spatstat (>= 2.0-0) to DESCRIPTION (and NAMESPACE).

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -34,7 +34,7 @@ Depends:
 Imports:
     lattice,
     goftest,
-    spatstat.geom, spatstat.core,
+    spatstat.geom, spatstat.core, spatstat (>= 2.0-0),
     Rcpp,
     fields
 LinkingTo: Rcpp (>= 1.0.0)

--- a/NAMESPACE
+++ b/NAMESPACE
@@ -16,3 +16,4 @@ importFrom("lattice", "xyplot")
 importFrom("maps", "map")
 
 importFrom("Rcpp", "evalCpp")
+import("spatstat")


### PR DESCRIPTION
Hi Abdollah,
If it is not too much trouble I would like to have spatstat (2.0-0) in "Imports:" for now to make sure people don't have the sub-packages together with the old spatstat. Later on you can skip this dependency.
Btw. there was a problem with the function `catalog` when I ran R CMD check. You forgot to document the argument `roundoff`.
Best,
Ege