### PR TITLE
Adapt to new spatstat.random package.

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -35,7 +35,7 @@ Depends:
 Imports:
     lattice,
     goftest,
-    spatstat.geom, spatstat.core, spatstat (>= 2.0-0),
+    spatstat.geom, spatstat.core, spatstat.random,
     Rcpp,
     fields
 LinkingTo: Rcpp (>= 1.0.0)

--- a/NAMESPACE
+++ b/NAMESPACE
@@ -17,4 +17,7 @@ importFrom("lattice", "xyplot")
 importFrom("maps", "map")
 
 importFrom("Rcpp", "evalCpp")
-import("spatstat")
+import("spatstat.core")
+import("spatstat.geom")
+importFrom("spatstat.random", "rpoint")
+

--- a/R/morisitaindex.R
+++ b/R/morisitaindex.R
@@ -17,7 +17,7 @@ morisitaindex <- function(object, K=11, bwd=NULL, dimyx=NULL, cat.name=NULL)
   areaW <- spatstat.geom::area.owin(win)
   X <- spatstat.geom::ppp(xx, yy, window=win)
   Lam <- Smooth.catalog(object, bwd=bwd, dimyx=dimyx)
-  X.sim <- spatstat.core::rpoint(X$n, Lam, win=win, nsim=100)
+  X.sim <- spatstat.random::rpoint(X$n, Lam, win=win, nsim=100)
 
   k.add <- 1
   delta <- areaW / (1:K + k.add)^2

--- a/R/poisstest.R
+++ b/R/poisstest.R
@@ -28,7 +28,7 @@ poiss.test <- function(object, which="joint", r=NULL, lambda=NULL, bwd=NULL,
     X <- spatstat.geom::ppp(xx, yy, window=win, unitname=unitname)
     if (is.null(lambda))
       lambda <- Smooth.catalog(object, bwd=bwd, dimyx=dimyx)
-    X.sim <- spatstat.core::rpoint(X$n, lambda, win=win, nsim=nsim)
+    X.sim <- spatstat.random::rpoint(X$n, lambda, win=win, nsim=nsim)
     X.sim <- lapply(X.sim, function(x) { x$window <- win; x })
 
     if (is.null(r))


### PR DESCRIPTION
Random generators are being moved from `spatstat.core` to a new package `spatstat.random`. This should hopefully fix the problem for your package.